### PR TITLE
implement_copyright

### DIFF
--- a/.idea/copyright/Zero_Saver.xml
+++ b/.idea/copyright/Zero_Saver.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="allowReplaceRegexp" value="[[0-2]0[0-2][0-2]][ ]" />
+    <option name="keyword" value="Copyright [\d,-]+ The Zero Saver Authors\. All Rights Reserved\." />
+    <option name="notice" value="#set( &amp;#36;projectName = &quot;Zero Saver&quot;)&#10;Copyright &amp;#36;originalComment.match(&quot;Copyright ([\d,-]+)&quot;, 1, &quot;,&quot;)&amp;#36;today.year The &amp;#36;projectName Authors. All Rights Reserved.&#10;&#10;This file is part of Zero Saver.&#10;&#10;&amp;#36;projectName is free software: you can redistribute it and/or modify it under&#10;the terms of the GNU General Public License as published by the Free Software&#10;Foundation, either version 3 of the License, or (at your option) any later&#10;version.&#10;&#10;&amp;#36;projectName is distributed in the hope that it will be useful, but WITHOUT ANY&#10;WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR&#10;A PARTICULAR PURPOSE. See the GNU General Public License for more details.&#10;You should have received a copy of the GNU General Public License along with&#10;&amp;#36;projectName. If not, see &lt;https://www.gnu.org/licenses/&gt;." />
+    <option name="myName" value="Zero-Saver" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,15 @@
+<component name="CopyrightManager">
+  <settings>
+    <module2copyright>
+      <element module="All" copyright="Zero-Saver" />
+    </module2copyright>
+    <LanguageOptions name="Python">
+      <option name="fileTypeOverride" value="3" />
+      <option name="addBlankAfter" value="false" />
+      <option name="block" value="false" />
+    </LanguageOptions>
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="addBlankAfter" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>


### PR DESCRIPTION
## What?
1\. Add support for PyCharm copyright statement insertion
## Why?
1\. Remove some boilerplate from mental load and potential for inconsistency
## How?
1\. Implement copyright profile for bundled Copyright plugin in PyCharm
## Testing?
Tested on existing copyright statements. Correctly recognizes and replaces existing statements if out of date. Otherwise, the statements are not modified.
## Screenshots (optional)
0
## Anything Else?
Years in the "replace if matches" section must be manually updated.
Replacement only works per comment (limitation of copyright implementation in PyCharm). 
The missing component of the copyright and years should be verified if auto replacing.
Formatting is incorrect on initial paste (limitation of copyright implementation in PyCharm) but is fixed by the auto-formatter.
<!---
# Copyright 2023 The Zero Saver Authors. All Rights Reserved.
#
# This file is part of Zero Saver.
#
# Zero Saver is free software: you can redistribute it and/or modify it under
# the terms of the GNU General Public License as published by the Free Software
# Foundation, either version 3 of the License, or (at your option) any later
# version.
#
# Zero Saver is distributed in the hope that it will be useful, but WITHOUT ANY
# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
#
# You should have received a copy of the GNU General Public License along with
# Zero Saver. If not, see <https://www.gnu.org/licenses/>.
--->